### PR TITLE
CSS Sprockets pipeline and compression

### DIFF
--- a/lib/middleman-inliner.rb
+++ b/lib/middleman-inliner.rb
@@ -13,7 +13,7 @@ class Inliner < Middleman::Extension
     def inline_css(*names)
       names.map { |name|
         name += ".css" unless name.include?(".css")
-        css_path = sitemap.resources.select { |p| p.source_file.include?(name) }.first
+        css_path = sitemap.resources.select { |p| p.source_file.include?(name) unless p.source_file.nil? }.first
         "<style type='text/css'>#{css_path.render}</style>"
       }.reduce(:+)
     end

--- a/lib/middleman-inliner.rb
+++ b/lib/middleman-inliner.rb
@@ -13,8 +13,13 @@ class Inliner < Middleman::Extension
     def inline_css(*names)
       names.map { |name|
         name += ".css" unless name.include?(".css")
-        css_path = sitemap.resources.select { |p| p.source_file.include?(name) unless p.source_file.nil? }.first
-        "<style type='text/css'>#{css_path.render}</style>"
+        css_full = sprockets.find_asset(name).to_s
+        
+        compressor = ::Sass::SCSS::CssParser.new(css_full, name, 1).parse
+        compressor.options = {:style => :compressed}
+        css_compressed = compressor.render.strip
+        
+        "<style type='text/css'>#{css_compressed}</style>"
       }.reduce(:+)
     end
 


### PR DESCRIPTION
Sprockets importing (via comments, /*= require 'name' ) was not working for me, and sass imports via @import were unable to find the file to import.

This change fixed the errors for me with no adverse effects.

Note that a a refactoring has immediately become apparent - inline_css and inline_js are quite similar.

In the interest of clarity, I am leaving these methods as-is so that you can easily see the change that was made, and why,
