### PR TITLE
`inline_javascript_inline_tag` to `javascript_inline_tag`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install
 activate :inliner
 ```
 
-- Replace your `stylesheet_link_tag` and `javascript_include_tag` to `stylesheet_inline_tag` and `inline_javascript_inline_tag`
+- Replace your `stylesheet_link_tag` and `javascript_include_tag` to `stylesheet_inline_tag` and `javascript_inline_tag`
 
 To Speed your website
 =====================


### PR DESCRIPTION
Just ran across this typo after trying to use `inline_javascript_inline_tag` in my middleman project, only to have it error out. :)
