### PR TITLE
Fix to work with Middleman4

### DIFF
--- a/lib/middleman-inliner.rb
+++ b/lib/middleman-inliner.rb
@@ -3,10 +3,6 @@ require 'middleman-core'
 class Inliner < Middleman::Extension
   def initialize(app, options_hash={}, &block)
     super
-
-    app.compass_config do |config|
-      config.output_style = :compressed
-    end
   end
 
   helpers do

--- a/lib/middleman-inliner.rb
+++ b/lib/middleman-inliner.rb
@@ -40,4 +40,4 @@ class Inliner < Middleman::Extension
   end
 end
 
-Inliner.register(:inliner)
+Middleman::Extensions.register(:inliner, Inliner)


### PR DESCRIPTION
middleman-inliner does not work with Middleman 4.x because they changed the interface by which an extension registers itself, but the change is trivial.

I also removed the bit in the constructor that references `app.compass_config` because I wasn't using Compass, and it did not seem to be required for Inliner to work.  If this is still necessary to work with projects using Compass, then I apologise for ripping it out, and I would like to request that Compass is an optional dependency.

Finally, I suspect these changes, though minor, will break compatibility with Middleman 3, but I'm not sure how you would want to handle that (maybe it would be appropriate to bump the major version number of Inliner?).